### PR TITLE
Handle missing repo clone and sanitize watcher config

### DIFF
--- a/opt/syncgitconfig/bin/syncgitconfig-watch
+++ b/opt/syncgitconfig/bin/syncgitconfig-watch
@@ -8,7 +8,28 @@ now(){ date '+%F %T'; }
 log(){ echo "[$(now)] $*" | tee -a "$LOGFILE"; }
 
 # Leer config mínima (sin depender de yq)
-val(){ awk -F': ' -v k="$1" '$1==k {print $2}' "$CONF" | tr -d "\"'"; }
+val(){
+  local key="$1"
+  awk -v k="$key" '
+    function trim(s){ sub(/^[[:space:]]+/, "", s); sub(/[[:space:]]+$/, "", s); return s }
+    /^[[:space:]]*#/ {next}
+    {
+      line=$0
+      if (match(line, "^[[:space:]]*" k ":[[:space:]]*(.*)$", arr)) {
+        val=arr[1]
+        sub(/[[:space:]]+#.*/, "", val)
+        val=trim(val)
+        if (val ~ /^".*"$/) {
+          sub(/^"/, "", val); sub(/"$/, "", val)
+        } else if (val ~ /^'\''.*'\''$/) {
+          sub(/^'\''/, "", val); sub(/'\''$/, "", val)
+        }
+        print val
+        exit
+      }
+    }
+  ' "$CONF"
+}
 
 [[ -f "$CONF" ]] || { log "[ERR] No existe $CONF"; exit 1; }
 REPO_PATH="$(val repo_path)"


### PR DESCRIPTION
## Summary
- automatically clone the configured remote when the local repo checkout is missing
- avoid mutating non-empty directories that are not git checkouts
- sanitize syncgitconfig-watch configuration parsing so inline comments do not break repo detection

## Testing
- bash -n opt/syncgitconfig/lib/common.sh
- bash -n opt/syncgitconfig/bin/syncgitconfig-watch

------
https://chatgpt.com/codex/tasks/task_e_68cfeba3a1e8832dab3e5fdefcbe35d4