### PR TITLE
Harden insecure git clone handling

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -37,10 +37,58 @@ COOLDOWN="60"
 NON_INTERACTIVE=0
 INSECURE=0
 
+RESTORE_GIT_SSL_VERIFY=0
+PREVIOUS_GIT_SSL_VERIFY_STATE="__unset__"
+
 c_green(){ printf "\033[1;32m%s\033[0m\n" "$*"; }
 c_yellow(){ printf "\033[1;33m%s\033[0m\n" "$*"; }
 c_red(){ printf "\033[1;31m%s\033[0m\n" "$*"; }
 log(){ echo "[$(date +'%F %T')] $*" | tee -a "$LOGFILE" >&2; }
+
+git_clone_repo(){
+  local url="$1" dest="$2"
+  local -a git_cmd
+
+  if (( INSECURE )); then
+    c_yellow "[WARN] --insecure activo: clonando sin verificación SSL."
+    git_cmd=(git -c http.sslVerify=false clone "$url" "$dest")
+    if ! env GIT_SSL_NO_VERIFY=true "${git_cmd[@]}" 2>&1 | tee -a "$LOGFILE"; then
+      return 1
+    fi
+    return 0
+  fi
+
+  git_cmd=(git clone "$url" "$dest")
+  "${git_cmd[@]}" 2>&1 | tee -a "$LOGFILE"
+}
+
+configure_insecure_git_ssl(){
+  (( INSECURE )) || return 0
+  command -v git >/dev/null 2>&1 || return 0
+
+  if (( ! RESTORE_GIT_SSL_VERIFY )); then
+    if git config --global --get http.sslVerify >/dev/null 2>&1; then
+      PREVIOUS_GIT_SSL_VERIFY_STATE="$(git config --global --get http.sslVerify 2>/dev/null || echo false)"
+    else
+      PREVIOUS_GIT_SSL_VERIFY_STATE="__unset__"
+    fi
+    RESTORE_GIT_SSL_VERIFY=1
+  fi
+
+  git config --global http.sslVerify false >/dev/null 2>&1 || true
+  log "[WARN] --insecure: http.sslVerify=false configurado temporalmente (global)."
+}
+
+restore_git_ssl_verify(){
+  (( RESTORE_GIT_SSL_VERIFY )) || return 0
+  command -v git >/dev/null 2>&1 || return 0
+
+  if [[ "$PREVIOUS_GIT_SSL_VERIFY_STATE" == "__unset__" ]]; then
+    git config --global --unset http.sslVerify >/dev/null 2>&1 || true
+  else
+    git config --global http.sslVerify "$PREVIOUS_GIT_SSL_VERIFY_STATE" >/dev/null 2>&1 || true
+  fi
+}
 
 usage() {
   cat <<EOF
@@ -71,6 +119,7 @@ EOF
 
 require_root(){ (( EUID == 0 )) || { c_red "Necesitas sudo/root."; exit 1; }; }
 trap 'c_red "⚠️  Error durante la instalación. Revisa el log: $LOGFILE"' ERR
+trap 'restore_git_ssl_verify' EXIT
 
 ### ========= Parseo de flags =========
 while (( "$#" )); do
@@ -83,12 +132,31 @@ while (( "$#" )); do
     --host)            shift; HOST_NAME="${1:-}";;
     --cooldown)        shift; COOLDOWN="${1:-}";;
     --non-interactive) NON_INTERACTIVE=1 ;;
-    --insecure)        INSECURE=1 ;;
+    --insecure)
+      INSECURE=1
+      if (( $# >= 2 )); then
+        INSECURE_VALUE="${2,,}"
+        case "$INSECURE_VALUE" in
+          1|true|yes) shift ;;
+          0|false|no) INSECURE=0; shift ;;
+        esac
+      fi
+      ;;
+    --insecure=*)
+      INSECURE_VALUE="${1#--insecure=}"
+      case "${INSECURE_VALUE,,}" in
+        1|true|yes) INSECURE=1 ;;
+        0|false|no) INSECURE=0 ;;
+        *) c_red "Valor inválido para --insecure: ${INSECURE_VALUE}"; usage; exit 1 ;;
+      esac
+      ;;
     -h|--help)         usage; exit 0 ;;
     *) c_red "Opción desconocida: $1"; usage; exit 1 ;;
   esac
   shift
 done
+
+unset -v INSECURE_VALUE || true
 
 require_root
 mkdir -p "$LOG_DIR" "$ETC_DIR" "$CREDENTIALS_DIR"
@@ -176,16 +244,20 @@ else
 fi
 
 ### ========= Clonado del repo =========
+configure_insecure_git_ssl
 log "[INFO] Clonando repo en ${REPO_PATH}"
 mkdir -p "$REPO_PATH"
 if [[ -d "$REPO_PATH/.git" ]]; then
   log "[INFO] Ya existe un repositorio en ${REPO_PATH}, omito clonación."
 else
-  if (( INSECURE )); then
-    c_yellow "[WARN] --insecure activo: clonando sin verificación SSL."
-    GIT_SSL_NO_VERIFY=true git -c http.sslVerify=false clone "$REMOTE_URL" "$REPO_PATH" 2>&1 | tee -a "$LOGFILE"
-  else
-    git clone "$REMOTE_URL" "$REPO_PATH" 2>&1 | tee -a "$LOGFILE"
+  if ! git_clone_repo "$REMOTE_URL" "$REPO_PATH"; then
+    if (( INSECURE )); then
+      log "[ERROR] git clone falló incluso con --insecure habilitado."
+    else
+      log "[ERROR] git clone falló. Si es un problema de certificados, vuelve a ejecutar con --insecure."
+    fi
+    c_red "[ERROR] No se pudo clonar el repositorio remoto $REMOTE_URL"
+    exit 1
   fi
 fi
 


### PR DESCRIPTION
## Summary
- add a helper that clones repositories with SSL verification disabled when `--insecure` is passed
- accept optional boolean values for `--insecure` and surface failures through the shared logger
- temporarily force Git's global `http.sslVerify` to false when `--insecure` is requested and restore the previous value at exit so certificate errors are bypassed reliably

## Testing
- `bash -n install.sh`


------
https://chatgpt.com/codex/tasks/task_e_68d00ba39040832dbeb3e19cbddf8721