### PR TITLE
Improve syncgitconfig flag handling and logging

### DIFF
--- a/opt/syncgitconfig/bin/syncgitconfig-run
+++ b/opt/syncgitconfig/bin/syncgitconfig-run
@@ -8,6 +8,42 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=/opt/syncgitconfig/lib/common.sh
 . "$SCRIPT_DIR/../lib/common.sh"
 
+dest_within_repo_or_die() {
+  local dest="$1" repo_root="$2" app="$3"
+
+  if [[ "$dest" == /* ]]; then
+    err "apps[$app].dest no puede ser absoluto: $dest"
+    exit 1
+  fi
+  if [[ "$dest" =~ (^|/)[.][.](|/|$) ]]; then
+    err "apps[$app].dest contiene '..': $dest"
+    exit 1
+  fi
+
+  local resolved=""
+  if command -v realpath >/dev/null 2>&1; then
+    resolved="$(realpath -m "$repo_root/$dest" 2>/dev/null || true)"
+  elif command -v python3 >/dev/null 2>&1; then
+    resolved="$(python3 - "$repo_root" "$dest" <<'PY'
+import os, sys
+base = sys.argv[1]
+sub = sys.argv[2]
+print(os.path.normpath(os.path.join(base, sub)))
+PY
+)"
+  else
+    resolved="$repo_root/$dest"
+  fi
+
+  case "$resolved" in
+    "$repo_root"|"$repo_root"/*) ;; 
+    *)
+      err "apps[$app].dest apunta fuera del repo: $dest"
+      exit 1
+      ;;
+  esac
+}
+
 main() {
   require_cmd rsync git install || exit 1
   load_config_yaml "$CONF_PATH"
@@ -20,6 +56,8 @@ main() {
   local STAGING_ROOT="$CFG_staging_path/$CFG_host"
   local REPO_HOST_ROOT="$CFG_repo_path/envs/$CFG_env/hosts/$CFG_host"
   mkdir -p "$STAGING_ROOT" "$REPO_HOST_ROOT"
+
+  local staging_changed=0
 
   local -a RSYNC_FLAGS; RSYNC_FLAGS=(-a --delete --itemize-changes)
   local -a EXCL; read -r -a EXCL <<<"$(rsync_exclude_flags)"
@@ -36,6 +74,8 @@ main() {
   for ((i=0; i<${#APP_NAMES[@]}; i++)); do
     local app="${APP_NAMES[$i]}" dest="${APP_DESTS[$i]}"
     [[ -z "$dest" ]] && dest="apps/$app"
+    APP_DESTS[$i]="$dest"
+    dest_within_repo_or_die "$dest" "$REPO_HOST_ROOT" "$app"
     local staged_app_root="$STAGING_ROOT/$dest"
     mkdir -p "$staged_app_root"
 
@@ -52,10 +92,27 @@ main() {
             if [[ "$src" == "$strip"* ]]; then
               rel="${src#"$strip"}"; [[ "$rel" == "/" ]] && rel=""
             fi
-            local tgt="$staged_app_root/$rel"
+            local tgt="$staged_app_root/${rel#/}"
             mkdir -p "$tgt"
-            log "DIR: $src -> $dest/$rel"
-            rsync "${RSYNC_FLAGS[@]}" "${EXCL[@]}" "$src/" "$tgt/" | tee -a "$LOG_FILE" || true
+            local display="$dest"
+            [[ -n "${rel#/}" ]] && display="$dest/${rel#/}"
+            local rsync_out=""
+            rsync_out="$(rsync "${RSYNC_FLAGS[@]}" "${EXCL[@]}" "$src/" "$tgt/" 2>&1)"
+            local rsync_rc=$?
+            if (( rsync_rc != 0 )); then
+              warn "DIR: $src -> $display (rsync falló con código $rsync_rc)"
+              if [[ -n "$rsync_out" ]]; then
+                while IFS= read -r line; do log "    $line"; done <<<"$rsync_out"
+              fi
+              continue
+            fi
+            if [[ -n "$rsync_out" ]]; then
+              staging_changed=1
+              log "DIR: $src -> $display (cambios)"
+              while IFS= read -r line; do log "    $line"; done <<<"$rsync_out"
+            else
+              log "DIR: $src -> $display (sin cambios)"
+            fi
           else
             warn "Directorio no existe: $src"
           fi
@@ -63,8 +120,15 @@ main() {
           if [[ -f "$src" ]]; then
             local rel="${src#"$strip"}"; rel="${rel#/}"   # quita leading /
             local tgt="$staged_app_root/$rel"
-            log "FILE: $src -> $dest/$rel"
-            install -D -m 0644 "$src" "$tgt"
+            local display="$dest"
+            [[ -n "$rel" ]] && display="$dest/$rel"
+            if [[ -f "$tgt" ]] && cmp -s "$src" "$tgt"; then
+              log "FILE: $src -> $display (sin cambios)"
+            else
+              install -D -m 0644 "$src" "$tgt"
+              staging_changed=1
+              log "FILE: $src -> $display (actualizado)"
+            fi
           else
             warn "Fichero no existe: $src"
           fi
@@ -79,8 +143,13 @@ main() {
   log "Sync STAGING -> REPO"
   rsync "${RSYNC_FLAGS[@]}" "${EXCL[@]}" "$STAGING_ROOT/" "$REPO_HOST_ROOT/" | tee -a "$LOG_FILE" || true
 
+  local staging_has_content=1
+  if [[ -z "$(find "$STAGING_ROOT" -mindepth 1 -type f -print -quit 2>/dev/null)" ]]; then
+    staging_has_content=0
+  fi
+
   # Commit/push (commit único; el mensaje incluye host y env)
-  git_commit_and_push "$CFG_repo_path" "$REPO_HOST_ROOT" "$CFG_env" "$CFG_host"
+  git_commit_and_push "$CFG_repo_path" "$REPO_HOST_ROOT" "$CFG_env" "$CFG_host" "$STAGING_ROOT" "$staging_changed" "$staging_has_content"
 
   ok "RUN completado."
   log "=== END $CFG_host ==="

--- a/opt/syncgitconfig/bin/syncgitconfig-watch
+++ b/opt/syncgitconfig/bin/syncgitconfig-watch
@@ -1,82 +1,97 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-CONF="/etc/syncgitconfig/syncgitconfig.yaml"
-LOGFILE="/var/log/syncgitconfig/syncgitconfig.log"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CONF_PATH="${CONF_PATH:-/etc/syncgitconfig/syncgitconfig.yaml}"
+# shellcheck source=/opt/syncgitconfig/lib/common.sh
+. "$SCRIPT_DIR/../lib/common.sh"
 
-now(){ date '+%F %T'; }
-log(){ echo "[$(now)] $*" | tee -a "$LOGFILE"; }
+main() {
+  [[ -f "$CONF_PATH" ]] || { err "No existe $CONF_PATH"; exit 1; }
 
-# Leer config mínima (sin depender de yq)
-val(){
-  local key="$1"
-  awk -v k="$key" '
-    function trim(s){ sub(/^[[:space:]]+/, "", s); sub(/[[:space:]]+$/, "", s); return s }
-    /^[[:space:]]*#/ {next}
-    {
-      line=$0
-      if (match(line, "^[[:space:]]*" k ":[[:space:]]*(.*)$", arr)) {
-        val=arr[1]
-        sub(/[[:space:]]+#.*/, "", val)
-        val=trim(val)
-        if (val ~ /^".*"$/) {
-          sub(/^"/, "", val); sub(/"$/, "", val)
-        } else if (val ~ /^'\''.*'\''$/) {
-          sub(/^'\''/, "", val); sub(/'\''$/, "", val)
-        }
-        print val
-        exit
-      }
-    }
-  ' "$CONF"
-}
+  load_config_yaml "$CONF_PATH" || exit 1
 
-[[ -f "$CONF" ]] || { log "[ERR] No existe $CONF"; exit 1; }
-REPO_PATH="$(val repo_path)"
-REMOTE_URL="$(val remote_url)"
-COOLDOWN="$(val cooldown)"; [[ -n "$COOLDOWN" ]] || COOLDOWN=60
+  local repo_path="$CFG_repo_path"
+  local cooldown="$CFG_cooldown_seconds"
 
-# Extraer array watch_paths (líneas siguientes con '- ')
-mapfile -t WATCH_PATHS < <(awk '/^watch_paths:/{flag=1;next} /^\S/{flag=0} flag&&/^-/{gsub("- ","",$0); print $0}' "$CONF")
-[[ ${#WATCH_PATHS[@]} -gt 0 ]] || WATCH_PATHS=("/etc/systemd")
-
-if [[ ! -d "$REPO_PATH/.git" ]]; then
-  log "[ERR] repo_path no es un checkout Git: $REPO_PATH"
-fi
-
-log "Watcher escuchando en: ${WATCH_PATHS[*]} (cooldown ${COOLDOWN}s)"
-last_run=0
-
-while true; do
-  inotifywait -q -e modify,create,delete,move "${WATCH_PATHS[@]}" >/dev/null 2>&1 || sleep 1
-  now_sec=$(date +%s)
-  if (( now_sec - last_run < COOLDOWN )); then
-    log "[WARN] Dentro de cooldown (${COOLDOWN}s); salto."
-    continue
+  local -a candidates=()
+  if (( ${#WATCH_PATHS[@]} )); then
+    candidates=("${WATCH_PATHS[@]}")
   fi
-  last_run=$now_sec
+  if (( ${#candidates[@]} == 0 )); then
+    warn "watch_paths vacío en YAML; usando fallback /etc/systemd"
+    candidates=("/etc/systemd")
+  fi
 
-  # Ejecutar todos los app-sync-* si existen
-  for s in /opt/syncgitconfig/bin/app-sync-*; do
-    [[ -x "$s" ]] && { log "[INFO] Ejecutando $(basename "$s")"; "$s" || log "[WARN] $(basename "$s") devolvió código $?"; }
+  local -a watch_list=()
+  for path in "${candidates[@]}"; do
+    [[ -z "$path" ]] && continue
+    if [[ -e "$path" ]]; then
+      watch_list+=("$path")
+    else
+      warn "Ruta en watch_paths no existe: $path"
+    fi
   done
 
-  # Commit y push si hay cambios
-  if [[ -d "$REPO_PATH/.git" ]]; then
-    if ! git -C "$REPO_PATH" diff --quiet || ! git -C "$REPO_PATH" diff --cached --quiet; then
-      git -C "$REPO_PATH" add -A
-      git -C "$REPO_PATH" commit -m "syncgitconfig: auto-commit $(date -Iseconds)"
-      if git -C "$REPO_PATH" push; then
-        log "[OK] Cambios empujados."
-      else
-        log "[WARN] Push falló; intentando pull --ff-only y reintento."
-        if git -C "$REPO_PATH" pull --ff-only && git -C "$REPO_PATH" push; then
-          log "[OK] Resuelto tras pull."
-        else
-          log "[ERR] No se pudo resolver el push."
-        fi
-      fi
-    fi
+  if (( ${#watch_list[@]} == 0 )); then
+    warn "Ninguna ruta de watch_paths es válida; usando fallback /etc/systemd"
+    watch_list=("/etc/systemd")
   fi
 
-done
+  if [[ ! -d "$repo_path/.git" ]]; then
+    err "repo_path no es un checkout Git válido: $repo_path"
+  fi
+
+  log "Watcher inicializado (cooldown ${cooldown}s)"
+  log "Rutas vigiladas:"
+  for path in "${watch_list[@]}"; do
+    log "  - $path"
+  done
+
+  local last_run=0
+
+  while true; do
+    if ! inotifywait -q -e modify,create,delete,move "${watch_list[@]}" >/dev/null 2>&1; then
+      sleep 1
+      continue
+    fi
+
+    local now_sec
+    now_sec="$(date +%s)"
+    if (( now_sec - last_run < cooldown )); then
+      log "[WARN] Dentro de cooldown (${cooldown}s); evento ignorado."
+      continue
+    fi
+    last_run=$now_sec
+
+    for script in /opt/syncgitconfig/bin/app-sync-*; do
+      [[ -x "$script" ]] || continue
+      log "[INFO] Ejecutando $(basename "$script")"
+      "$script" || {
+        local rc=$?
+        log "[WARN] $(basename "$script") devolvió código $rc"
+      }
+    done
+
+    if [[ -d "$repo_path/.git" ]]; then
+      if ! git -C "$repo_path" diff --quiet || ! git -C "$repo_path" diff --cached --quiet; then
+        git -C "$repo_path" add -A
+        git -C "$repo_path" -c user.name="Infra Backup Bot" -c user.email="infra-backup@${CFG_host}" commit -m "syncgitconfig: auto-commit $(date -Iseconds)"
+        if git -C "$repo_path" push; then
+          log "[OK] Cambios empujados."
+        else
+          log "[WARN] Push falló; intentando pull --ff-only y reintento."
+          if git -C "$repo_path" pull --ff-only && git -C "$repo_path" push; then
+            log "[OK] Resuelto tras pull."
+          else
+            log "[ERR] No se pudo resolver el push."
+          fi
+        fi
+      else
+        log "[INFO] Evento recibido pero sin cambios pendientes en Git."
+      fi
+    fi
+  done
+}
+
+main "$@"

--- a/opt/syncgitconfig/config.example.yaml
+++ b/opt/syncgitconfig/config.example.yaml
@@ -3,7 +3,7 @@
 # ============================================================
 # Edita con cuidado y reinicia servicios tras cambios:
 #   sudo systemctl restart syncgitconfig-watch.service
-#   sudo systemctl restart syncgitconfig-sync.service
+#   sudo systemctl restart syncgitconfig.service
 # ============================================================
 
 # ---- Parámetros globales ----

--- a/readme.md
+++ b/readme.md
@@ -92,6 +92,13 @@ tail -n 50 /var/log/syncgitconfig/syncgitconfig.log
 
 Archivo: `/etc/syncgitconfig/syncgitconfig.yaml` (el **único** que editas).
 
+> ℹ️ Después de cambiar el YAML reinicia los servicios para que recojan la nueva configuración:
+>
+> ```bash
+> sudo systemctl restart syncgitconfig.service
+> sudo systemctl restart syncgitconfig-watch.service
+> ```
+
 ```yaml
 repo_path: /opt/configs-host
 remote_url: https://gitea.example.local/ORG/configs-host.git
@@ -169,7 +176,7 @@ apps:
   Arranca al boot, monitoriza rutas de `apps[].sources`, aplica **cooldown 60 s** y ejecuta el run.
 
 * **One-shot** manual: `syncgitconfig.service`
-  Ejecuta una pasada bajo demanda.
+  Ejecuta una pasada bajo demanda. Es de tipo *oneshot*: tras completarse aparece como `inactive (dead)` en `systemctl status`.
 
 Comandos útiles:
 
@@ -250,6 +257,9 @@ tail -f /var/log/syncgitconfig/syncgitconfig.log
   ```bash
   systemctl is-active syncgitconfig-watch.service
   ```
+
+* **Fallo TLS/CA al clonar o hacer pull**
+  Importa la CA corporativa en el sistema (por ejemplo, copia el `.crt` a `/usr/local/share/ca-certificates/` y ejecuta `update-ca-certificates`). Utiliza `--insecure` únicamente como medida temporal.
 
 * **`git push` pide credenciales / falla**
   Verifica `remote_url` y el contenido/permisos de `.git-credentials` (600).


### PR DESCRIPTION
## Summary
- harden sync runs by validating destination paths, tracking whether staging changed, and surfacing the reason when nothing is committed
- centralise YAML parsing of watch_paths, rework the watcher to honour the list with clearer logging, and ensure commits work even without pre-set git identity
- improve installer robustness by validating --insecure values, enforcing executable permissions, configuring repo-level git identity, and documenting TLS/oneshot behaviours

## Testing
- bash -n install.sh
- bash -n opt/syncgitconfig/lib/common.sh
- bash -n opt/syncgitconfig/bin/syncgitconfig-run
- bash -n opt/syncgitconfig/bin/syncgitconfig-watch

------
https://chatgpt.com/codex/tasks/task_e_68d017a67228832d96a74f4cb1d9708a