### PR TITLE
Support non-interactive HTTPS/SSH auth and declarative app config

### DIFF
--- a/etc/syncgitconfig/syncgitconfig.yaml
+++ b/etc/syncgitconfig/syncgitconfig.yaml
@@ -6,19 +6,32 @@ host: auto                                    # o un FQDN fijo como "host01.exam
 staging_path: /var/lib/syncgitconfig/staging
 cooldown_seconds: 60
 
-watch_paths:
-  - "/etc/systemd/system"
-# paths:
+environments:
+  prod:
+    hosts:
+      auto:
+        apps:
+          systemd:
+            paths:
+              - /etc/systemd/system
+          # phpipam:
+          #   paths:
+          #     - /var/www/phpipam
+# watch_paths:
 #   - "/etc/systemd/system"
 
 # === Autenticación (HTTPS + token) ===
 auth:
   method: https_token
   username: syncgit-bot
-  # Opción A (recomendada): indicar el fichero de credenciales (git-credential-store)
   token_file: /etc/syncgitconfig/credentials/.git-credentials
-  # Opción B (bootstrap rápido): PON TEMPORALMENTE EL TOKEN AQUÍ y el instalador lo migrará
   # token_inline: "PON_AQUI_TU_TOKEN_Y_LUEGO_SE_BORRA"
+  # method: https_netrc
+  # netrc_file: /root/.netrc
+  # method: ssh
+  # ssh_key_path: /root/.ssh/id_ed25519
+  # ssh_known_hosts: /etc/ssh/ssh_known_hosts
+  # ssh_extra_args: "-o IdentitiesOnly=yes"
 
 # === Exclusiones globales ===
 exclude:
@@ -31,13 +44,13 @@ exclude:
   - "*.srl"
 
 # === Modelo por aplicación ===
-apps:
-  - name: systemd
-    dest: "apps/systemd"
-    sources:
-      - path: "/etc/systemd/system"
-        type: dir
-        strip_prefix: "/etc/systemd/system"
+# apps:
+#   - name: systemd
+#     dest: "apps/systemd"
+#     sources:
+#       - path: "/etc/systemd/system"
+#         type: dir
+#         strip_prefix: "/etc/systemd/system"
 
   # Ejemplos para activar cuando quieras:
   # - name: ssh

--- a/opt/syncgitconfig/README.md
+++ b/opt/syncgitconfig/README.md
@@ -1,18 +1,18 @@
 # syncgitconfig
 
-Backup granular de configuraciones por servidor, en Git, con staging y watcher inotify.
+Backup granular de configuraciones por servidor, en Git (HTTPS/SSH), con staging y watcher inotify.
 
 ## Piezas
 - Config YAML: `/etc/syncgitconfig/syncgitconfig.yaml`
-- Credenciales (HTTPS token): `/etc/syncgitconfig/credentials/.git-credentials` (600)
+- Autenticación: token (`auth.token_file`), `.netrc` (`auth.method: https_netrc`) o clave SSH (`auth.method: ssh`).
 - Binarios: `/opt/syncgitconfig/bin/*`
 - Estado: `/var/lib/syncgitconfig`
 - Logs: `/var/log/syncgitconfig`
 - Servicios: `syncgitconfig.service`, `syncgitconfig-watch.service`
 
 ## Primeros pasos
-1. Edita `syncgitconfig.yaml` (remote_url, repo_path, paths/apps, watch_paths).
-2. Pon token en `token_inline` o en `.git-credentials`.
+1. Edita `syncgitconfig.yaml` (remote_url, repo_path, bloque `environments`/`apps`).
+2. Define credenciales (`auth.method`: `https_token`, `https_netrc` o `ssh`).
 3. Ejecuta `/opt/syncgitconfig/bin/syncgitconfig-install`.
 4. Sembrar snapshot inicial (opcional): `/opt/syncgitconfig/bin/syncgitconfig-seed`.
 5. Verifica con `/opt/syncgitconfig/bin/syncgitconfig-status`.

--- a/opt/syncgitconfig/bin/syncgitconfig-install
+++ b/opt/syncgitconfig/bin/syncgitconfig-install
@@ -62,37 +62,47 @@ UNIT
 
 migrate_token_inline_to_credentials() {
   # Si token_inline existe en YAML, construye entrada en token_file y lo "redacta" del YAML
-  if [[ -n "$AUTH_token_inline" ]]; then
-    [[ -n "$AUTH_username" ]] || AUTH_username="token"
-    [[ -n "$AUTH_token_file" ]] || AUTH_token_file="/etc/syncgitconfig/credentials/.git-credentials"
-    mkdir -p "$(dirname "$AUTH_token_file")"; chmod 700 "$(dirname "$AUTH_token_file")" || true
-
-    # De remote_url sacamos host y path (manteniendo https://)
-    local url="$CFG_remote_url"
-    if [[ "$url" != https://* ]]; then
-      err "remote_url no es https:// — revisa config"; exit 1
-    fi
-    local proto="https://"
-    local rest="${url#https://}"          # gitea.example/ORG/repo.git
-    # Escribimos línea de credenciales
-    echo "https://${AUTH_username}:${AUTH_token_inline}@${rest}" > "$AUTH_token_file"
-    chmod 600 "$AUTH_token_file"
-
-    # Configura git-credential-store para usar ese fichero en el repo (luego al clonar lo usaremos)
-    git config --global credential.helper "store --file=$AUTH_token_file" || true
-
-    # Redacta token_inline del YAML (sustituye su valor por ***)
-    sed -i 's/^\(\s*token_inline:\s*\).*/\1"REDACTED"/' "$CONF_PATH" || true
-    ok "Token migrado a $AUTH_token_file y redactado en YAML."
+  if [[ -z "$AUTH_token_inline" ]]; then
+    return
   fi
+
+  if [[ "$AUTH_effective_method" != "https_token" ]]; then
+    warn "token_inline definido pero auth.method no es https_token; se omite migración."
+    return
+  fi
+
+  [[ -n "$AUTH_username" ]] || AUTH_username="token"
+  [[ -n "$AUTH_token_file" ]] || AUTH_token_file="/etc/syncgitconfig/credentials/.git-credentials"
+  mkdir -p "$(dirname "$AUTH_token_file")"; chmod 700 "$(dirname "$AUTH_token_file")" || true
+
+  local url="$CFG_remote_url"
+  if [[ "$url" != https://* && "$url" != http://* ]]; then
+    warn "token_inline definido pero remote_url no es HTTPS: $url"
+    return
+  fi
+
+  local rest="$url"
+  rest="${rest#http://}"
+  rest="${rest#https://}"
+  echo "https://${AUTH_username}:${AUTH_token_inline}@${rest}" > "$AUTH_token_file"
+  chmod 600 "$AUTH_token_file"
+
+  git config --global credential.helper "store --file=$AUTH_token_file" || true
+
+  sed -i 's/^\(\s*token_inline:\s*\).*/\1"REDACTED"/' "$CONF_PATH" || true
+  ok "Token migrado a $AUTH_token_file y redactado en YAML."
 }
 
 clone_repo_if_missing() {
   local rp="$CFG_repo_path" url="$CFG_remote_url"
   mkdir -p "$rp"
   if [[ ! -d "$rp/.git" ]]; then
-    log "Clonando repo $url en $rp"
-    git clone "$url" "$rp"
+    local display="$(redact_remote_url "$url")"
+    log "Clonando repo $display en $rp"
+    if ! run_git clone "$url" "$rp"; then
+      err "git clone falló para $display"
+      exit 1
+    fi
   fi
   ok "Repo listo en $rp"
 }

--- a/opt/syncgitconfig/bin/syncgitconfig-pull
+++ b/opt/syncgitconfig/bin/syncgitconfig-pull
@@ -1,17 +1,34 @@
 #!/usr/bin/env bash
 set -euo pipefail
-CONF="/etc/syncgitconfig/syncgitconfig.yaml"
-REPO_PATH="$(awk -F': ' '/^repo_path:/ {print $2}' "$CONF" | tr -d "\"'")"
-[[ -n "${REPO_PATH:-}" ]] || { echo "[ERR] repo_path no definido en $CONF"; exit 1; }
-[[ -d "$REPO_PATH/.git" ]] || { echo "[ERR] $REPO_PATH no es un repo Git"; exit 1; }
-BR="$(git -C "$REPO_PATH" rev-parse --abbrev-ref HEAD 2>/dev/null || echo main)"
-echo "[INFO] Pull de $REPO_PATH (branch: $BR)"
-if git -C "$REPO_PATH" pull --ff-only; then
-  echo "[OK] Fast-forward aplicado."
-  exit 0
-fi
-echo "[WARN] Divergencia. Stash + reset a origin/$BR"
- git -C "$REPO_PATH" stash push -u -m "syncgitconfig-autostash-$(date -Iseconds)" || true
- git -C "$REPO_PATH" fetch --prune
- git -C "$REPO_PATH" reset --hard "origin/$BR"
- echo "[OK] Reset duro completado."
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CONF_PATH="${CONF_PATH:-/etc/syncgitconfig/syncgitconfig.yaml}"
+# shellcheck source=/opt/syncgitconfig/lib/common.sh
+. "$SCRIPT_DIR/../lib/common.sh"
+
+main() {
+  if ! load_config_yaml "$CONF_PATH"; then
+    err "No se pudo cargar la configuración ($CONF_PATH)"
+    exit 1
+  fi
+
+  local repo="$CFG_repo_path"
+  [[ -d "$repo/.git" ]] || { err "$repo no es un repo Git válido"; exit 1; }
+
+  local branch
+  branch="$(run_git -C "$repo" rev-parse --abbrev-ref HEAD 2>/dev/null || echo main)"
+  ok "Pull de $repo (branch: $branch)"
+
+  if run_git -C "$repo" pull --ff-only; then
+    ok "Repositorio actualizado."
+    exit 0
+  fi
+
+  warn "Divergencia detectada. Ejecutando stash + reset a origin/$branch"
+  run_git -C "$repo" stash push -u -m "syncgitconfig-autostash-$(date -Iseconds)" || true
+  run_git -C "$repo" fetch --prune || true
+  run_git -C "$repo" reset --hard "origin/$branch"
+  ok "Reset duro completado."
+}
+
+main "$@"

--- a/opt/syncgitconfig/bin/syncgitconfig-run
+++ b/opt/syncgitconfig/bin/syncgitconfig-run
@@ -176,13 +176,27 @@ main() {
     for ((s=0; s<${#SRC_APPIDX[@]}; s++)); do
       if (( SRC_APPIDX[$s] == i )); then
         local src="${SRC_PATHS[$s]}" typ="${SRC_TYPES[$s]}" strip="${SRC_STRIPS[$s]}"
-        [[ -z "$strip" ]] && strip="$src"
+        local effective_type="$typ"
+        local effective_strip="$strip"
 
-        if [[ "$typ" == "dir" ]]; then
+        if [[ "$effective_type" == "auto" || -z "$effective_type" ]]; then
+          if [[ -d "$src" ]]; then
+            effective_type="dir"
+            [[ -n "$effective_strip" ]] || effective_strip="$src"
+          elif [[ -f "$src" ]]; then
+            effective_type="file"
+            [[ -n "$effective_strip" ]] || effective_strip="$(dirname "$src")"
+          else
+            warn "Ruta no existe: $src"
+            continue
+          fi
+        fi
+
+        if [[ "$effective_type" == "dir" ]]; then
           if [[ -d "$src" ]]; then
             local rel="/"
-            if [[ "$src" == "$strip"* ]]; then
-              rel="${src#"$strip"}"; [[ "$rel" == "/" ]] && rel=""
+            if [[ "$src" == "$effective_strip"* ]]; then
+              rel="${src#"$effective_strip"}"; [[ "$rel" == "/" ]] && rel=""
             fi
             local tgt="$staged_app_root/${rel#/}"
             mkdir -p "$tgt"
@@ -208,9 +222,9 @@ main() {
           else
             warn "Directorio no existe: $src"
           fi
-        elif [[ "$typ" == "file" ]]; then
+        elif [[ "$effective_type" == "file" ]]; then
           if [[ -f "$src" ]]; then
-            local rel="${src#"$strip"}"; rel="${rel#/}"
+            local rel="${src#"$effective_strip"}"; rel="${rel#/}"
             local tgt="$staged_app_root/$rel"
             local display="$dest"
             [[ -n "$rel" ]] && display="$dest/$rel"

--- a/opt/syncgitconfig/bin/syncgitconfig-status
+++ b/opt/syncgitconfig/bin/syncgitconfig-status
@@ -1,59 +1,71 @@
 #!/usr/bin/env bash
 set -euo pipefail
-CONF="/etc/syncgitconfig/syncgitconfig.yaml"
 
-val(){
-  local key="$1"
-  awk -v key="$key" '
-    function trim(s) { sub(/^[ \t\r\n]+/, "", s); sub(/[ \t\r\n]+$/, "", s); return s }
-    /^[[:space:]]*#/ { next }
-    {
-      line = $0
-      sub(/[[:space:]]+#.*/, "", line)
-      if (match(line, /^[[:space:]]*([^:]+):[[:space:]]*(.*)$/, m)) {
-        k = trim(m[1])
-        if (k == key) {
-          v = trim(m[2])
-          gsub(/^"|"$/, "", v)
-          gsub(/^\047|\047$/, "", v)
-          print v
-          exit
-        }
-      }
-    }
-  ' "$CONF"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CONF_PATH="${CONF_PATH:-/etc/syncgitconfig/syncgitconfig.yaml}"
+# shellcheck source=/opt/syncgitconfig/lib/common.sh
+. "$SCRIPT_DIR/../lib/common.sh"
+
+print_header() {
+  echo "== syncgitconfig status =="
+  if [[ -f "$CONF_PATH" ]]; then
+    echo "Config: $CONF_PATH"
+  else
+    echo "Config: (no existe)"
+  fi
 }
 
-ENV="$(val env 2>/dev/null || true)"
-HOST="$(val host 2>/dev/null || true)"
-REPO="$(val repo_path 2>/dev/null || true)"
-REMOTE="$(val remote_url 2>/dev/null || true)"
-COOLDOWN="$(val cooldown 2>/dev/null || true)"
-[[ -z "$COOLDOWN" ]] && COOLDOWN="$(val cooldown_seconds 2>/dev/null || true)"
+main() {
+  print_header
 
-echo "== syncgitconfig status =="
-[[ -f "$CONF" ]] && echo "Config: $CONF" || echo "Config: (no existe)"
-echo "Repo:   ${REPO:-}"
-echo "Remote: ${REMOTE:-}"
-echo "Env:    ${ENV:-}"
-echo "Host:   ${HOST:-}"
-echo "Cooldown: ${COOLDOWN:-}"
+  local load_ok=0
+  if [[ -f "$CONF_PATH" ]]; then
+    if load_config_yaml "$CONF_PATH"; then
+      load_ok=1
+    else
+      warn "No se pudo cargar el YAML de configuración"
+    fi
+  fi
 
-STAGING="/var/lib/syncgitconfig/staging/${HOST:-unknown}"
-echo "Staging: $STAGING"
+  local repo="$CFG_repo_path"
+  local remote_display="$(redact_remote_url "$CFG_remote_url")"
+  local env="$CFG_env"
+  local host="$CFG_host"
+  local cooldown="$CFG_cooldown_seconds"
 
-APPS_CNT=$(ls -1 /opt/syncgitconfig/bin/app-sync-* 2>/dev/null | wc -l || true)
-echo "Apps:   ${APPS_CNT}"
+  echo "Repo:   ${repo:-}"
+  echo "Remote: ${remote_display:-}"
+  echo "Env:    ${env:-}"
+  echo "Host:   ${host:-}"
+  echo "Cooldown: ${cooldown:-}"
 
-echo -e "\n-- Últimas 10 líneas del log --"
-LOGFILE="/var/log/syncgitconfig/syncgitconfig.log"
-[[ -f "$LOGFILE" ]] && tail -n 10 "$LOGFILE" || echo "(sin log)"
+  local staging="/var/lib/syncgitconfig/staging/${host:-unknown}"
+  echo "Staging: $staging"
 
-echo -e "\n-- Estado Git --"
-if [[ -n "${REPO:-}" && -d "$REPO/.git" ]]; then
-  git -C "$REPO" status -s || true
-else
-  echo "Repo no inicializado."
-fi
+  if (( load_ok )); then
+    echo "Apps:   ${#APP_NAMES[@]}"
+  else
+    echo "Apps:   (desconocido)"
+  fi
 
-echo -e "\nWatcher: $(systemctl is-active syncgitconfig-watch.service 2>/dev/null || echo unknown)"
+  echo -e "\n-- Últimas 10 líneas del log --"
+  local LOGFILE="/var/log/syncgitconfig/syncgitconfig.log"
+  if [[ -f "$LOGFILE" ]]; then
+    tail -n 10 "$LOGFILE"
+  else
+    echo "(sin log)"
+  fi
+
+  echo -e "\n-- Estado Git --"
+  if [[ -n "$repo" && -d "$repo/.git" ]]; then
+    run_git -C "$repo" status -s || true
+  else
+    echo "Repo no inicializado."
+  fi
+
+  local watcher_state
+  watcher_state="$(systemctl is-active syncgitconfig-watch.service 2>/dev/null || echo unknown)"
+  echo -e "\nWatcher: $watcher_state"
+}
+
+main "$@"

--- a/opt/syncgitconfig/config.example.yaml
+++ b/opt/syncgitconfig/config.example.yaml
@@ -13,15 +13,24 @@ repo_path: __REPO_PATH__   # Ruta local donde se clona el repo
 remote_url: __REMOTE_URL__ # URL remota del repo (HTTPS/SSH)
 cooldown: __COOLDOWN__     # Intervalo en segundos entre syncs
 
-# ---- Rutas vigiladas ----
-watch_paths:
-  - /etc/systemd            # unidades systemd
-  # - /etc/nginx            # ejemplo: configuración de nginx
-  # - /etc/php/8.2          # ejemplo: configuración PHP
-  # - /var/www/phpipam      # ejemplo: configs de phpIPAM
-  # - /etc/ssh              # ejemplo: configuración de SSH
+# ---- Modelo declarativo por entorno/host ----
+environments:
+  __ENV__:
+    hosts:
+      __HOST__:
+        apps:
+          systemd:
+            paths:
+              - /etc/systemd/system
+          # phpipam:
+          #   paths:
+          #     - /var/www/phpipam
 
-# ---- Snapshot directo (alternativa simple a apps) ----
+# ---- Watchers personalizados (opcional) ----
+# watch_paths:
+#   - /etc/systemd
+
+# ---- Snapshot directo (legacy) ----
 # paths:
 #   - /etc/systemd/system
 #   - /var/www/phpipam
@@ -31,15 +40,21 @@ watch_paths:
 #   - "*.log"
 #   - "/etc/nginx/sites-enabled/default"
 
-# ---- Ejemplo de múltiples repos (opcional) ----
-# repos:
-#   - name: phpipam
-#     repo_path: /opt/configs-phpipam
-#     remote_url: https://gitlab.local/phpipam.git
-#     watch_paths:
-#       - /var/www/phpipam
-#   - name: nginx
-#     repo_path: /opt/configs-nginx
-#     remote_url: https://gitlab.local/nginx.git
-#     watch_paths:
-#       - /etc/nginx
+# ---- Autenticación ----
+auth:
+  method: https_token        # https_token | https_netrc | ssh
+  username: syncgit-bot
+  token_file: /etc/syncgitconfig/credentials/.git-credentials
+  # token_inline: "PON TEMPORALMENTE EL TOKEN AQUÍ Y SE MIGRA"
+  # netrc_file: /root/.netrc
+  # ssh_key_path: /root/.ssh/id_ed25519
+  # ssh_known_hosts: /etc/ssh/ssh_known_hosts
+  # ssh_extra_args: "-o IdentitiesOnly=yes"
+
+# ---- Apps manuales (formato clásico) ----
+# apps:
+#   - name: systemd
+#     dest: "apps/systemd"
+#     sources:
+#       - path: "/etc/systemd/system"
+#         type: dir


### PR DESCRIPTION
## Summary
- extend common library to detect HTTPS token, netrc and SSH auth, configure git environment, and map the new `environments` YAML block into app sources
- update sync scripts to rely on the shared git wrapper, support auto type detection, and expose app counts/status from the parsed config
- document the new authentication methods and declarative `environments` layout in the examples and README files

## Testing
- bash -n opt/syncgitconfig/lib/common.sh
- bash -n opt/syncgitconfig/bin/syncgitconfig-run
- bash -n opt/syncgitconfig/bin/syncgitconfig-install
- bash -n opt/syncgitconfig/bin/syncgitconfig-pull
- bash -n opt/syncgitconfig/bin/syncgitconfig-status

------
https://chatgpt.com/codex/tasks/task_e_68d02aba5628832db0cb7a3771332d98