### PR TITLE
Respect repo layout and disable legacy legacy paths when using apps

### DIFF
--- a/opt/syncgitconfig/bin/syncgitconfig-run
+++ b/opt/syncgitconfig/bin/syncgitconfig-run
@@ -102,11 +102,6 @@ main() {
   require_cmd rsync git install || exit 1
   load_config_yaml "$CONF_PATH"
 
-  if [[ "$CFG_repo_layout" == "flat" && ${#APP_NAMES[@]} -gt 0 && ${#WATCH_PATHS[@]} -gt 0 ]]; then
-    warn "repo_layout=flat con 'apps' declarados: se ignoran 'watch_paths'."
-    WATCH_PATHS=()
-  fi
-
   acquire_lock_or_exit
   respect_cooldown_or_exit
 
@@ -114,20 +109,22 @@ main() {
 
   local STAGING_ROOT="$CFG_staging_path/$CFG_host"
   local REPO_HOST_ROOT
-  if [[ "$CFG_repo_layout" == "flat" ]]; then
-    REPO_HOST_ROOT="$CFG_repo_path"
-  else
-    REPO_HOST_ROOT="$CFG_repo_path/envs/$CFG_env/hosts/$CFG_host"
-  fi
+  REPO_HOST_ROOT="$(repo_host_root_path)"
   mkdir -p "$STAGING_ROOT" "$REPO_HOST_ROOT"
+
+  if (( ${#APP_NAMES[@]} > 0 )); then
+    rm -rf "$STAGING_ROOT/paths"
+  fi
 
   local staging_changed=0
 
   RSYNC_FLAGS=(-a --delete --itemize-changes)
   read -r -a EXCL <<<"$(rsync_exclude_flags)"
 
-  local -a EFFECTIVE_PATHS
-  EFFECTIVE_PATHS=("${PATHS[@]}")
+  local -a EFFECTIVE_PATHS=()
+  if (( ${#APP_NAMES[@]} == 0 )); then
+    EFFECTIVE_PATHS=("${PATHS[@]}")
+  fi
   local using_watch_paths_as_sources=0
   if (( ${#EFFECTIVE_PATHS[@]} == 0 && ${#WATCH_PATHS[@]} > 0 && ${#APP_NAMES[@]} == 0 )); then
     EFFECTIVE_PATHS=("${WATCH_PATHS[@]}")

--- a/opt/syncgitconfig/bin/syncgitconfig-watch
+++ b/opt/syncgitconfig/bin/syncgitconfig-watch
@@ -11,11 +11,6 @@ main() {
 
   load_config_yaml "$CONF_PATH" || exit 1
 
-  if [[ "$CFG_repo_layout" == "flat" && ${#APP_NAMES[@]} -gt 0 && ${#WATCH_PATHS[@]} -gt 0 ]]; then
-    warn "repo_layout=flat con 'apps' declarados: se ignoran 'watch_paths'."
-    WATCH_PATHS=()
-  fi
-
   local repo_path="$CFG_repo_path"
   local cooldown="$CFG_cooldown_seconds"
 
@@ -69,11 +64,7 @@ main() {
 
   local STAGING_ROOT="$CFG_staging_path/$CFG_host"
   local REPO_HOST_ROOT
-  if [[ "$CFG_repo_layout" == "flat" ]]; then
-    REPO_HOST_ROOT="$CFG_repo_path"
-  else
-    REPO_HOST_ROOT="$CFG_repo_path/envs/$CFG_env/hosts/$CFG_host"
-  fi
+  REPO_HOST_ROOT="$(repo_host_root_path)"
 
   local staging_has_content=0
   if [[ -d "$STAGING_ROOT" && -n "$(find "$STAGING_ROOT" -mindepth 1 -type f -print -quit 2>/dev/null)" ]]; then

--- a/opt/syncgitconfig/lib/common.sh
+++ b/opt/syncgitconfig/lib/common.sh
@@ -73,6 +73,14 @@ ensure_app_entry() {
   ENSURE_APP_LAST_IDX=$(( ${#APP_NAMES[@]} - 1 ))
 }
 
+repo_host_root_path() {
+  if [[ "$CFG_repo_layout" == "flat" ]]; then
+    printf '%s\n' "$CFG_repo_path"
+  else
+    printf '%s\n' "$CFG_repo_path/envs/$CFG_env/hosts/$CFG_host"
+  fi
+}
+
 build_command_string() {
   local out=""
   local part
@@ -531,6 +539,16 @@ load_config_yaml() {
 
   determine_auth_effective_method
   apply_environment_apps
+
+  if (( ${#APP_NAMES[@]} > 0 && ${#PATHS[@]} > 0 )); then
+    warn "Se ignoran 'paths' (modo legacy) porque hay 'apps' declarados."
+    PATHS=()
+  fi
+  if [[ "$CFG_repo_layout" == "flat" && ${#APP_NAMES[@]} -gt 0 && ${#WATCH_PATHS[@]} -gt 0 ]]; then
+    warn "repo_layout=flat con 'apps' declarados: se ignoran 'watch_paths'."
+    WATCH_PATHS=()
+  fi
+
   configure_git_auth_environment
   return 0
 }


### PR DESCRIPTION
## Summary
- add a shared helper to resolve the repo host root according to the selected layout and reuse it in the run/watch scripts
- clear legacy `paths/` staging content and ignore `paths` entries whenever apps are configured
- normalize configuration loading so repo_layout updates also disable conflicting watch_paths when using flat layout apps

## Testing
- bash -n opt/syncgitconfig/bin/syncgitconfig-run
- bash -n opt/syncgitconfig/bin/syncgitconfig-watch
- bash -n opt/syncgitconfig/lib/common.sh

------
https://chatgpt.com/codex/tasks/task_e_68d041daada8832db8204d2df65faa7e