### PR TITLE
Adjust repo layout to drop host level

### DIFF
--- a/opt/syncgitconfig/bin/syncgitconfig-run
+++ b/opt/syncgitconfig/bin/syncgitconfig-run
@@ -13,10 +13,11 @@ SEED_MODE=0
 
 usage() {
   cat <<'USAGE'
-Uso: syncgitconfig-run [--no-cooldown] [--seed]
+Uso: syncgitconfig-run [--no-cooldown] [--seed] [--once]
 
   --no-cooldown  Ejecuta ignorando la ventana de cooldown configurada.
   --seed         Fuerza snapshot inicial (implica --no-cooldown).
+  --once         Alias de compatibilidad (no tiene efecto adicional).
 USAGE
 }
 
@@ -30,6 +31,9 @@ parse_args() {
       --seed)
         SEED_MODE=1
         BYPASS_COOLDOWN=1
+        ;;
+      --once)
+        # Alias de compatibilidad con versiones anteriores del wrapper/systemd
         ;;
       -h|--help)
         usage
@@ -163,7 +167,8 @@ main() {
 
   ensure_git_repo_ready "$CFG_repo_path" "$CFG_remote_url" "$AUTH_token_file"
 
-  local STAGING_ROOT="$CFG_staging_path/$CFG_host"
+  local STAGING_ROOT
+  STAGING_ROOT="$(staging_root_path)"
   local REPO_HOST_ROOT
   REPO_HOST_ROOT="$(repo_host_root_path)"
   mkdir -p "$STAGING_ROOT" "$REPO_HOST_ROOT"

--- a/opt/syncgitconfig/bin/syncgitconfig-status
+++ b/opt/syncgitconfig/bin/syncgitconfig-status
@@ -39,8 +39,14 @@ main() {
   echo "Host:   ${host:-}"
   echo "Cooldown: ${cooldown:-}"
 
-  local staging="/var/lib/syncgitconfig/staging/${host:-unknown}"
-  echo "Staging: $staging"
+  local staging_display
+  if (( load_ok )); then
+    staging_display="$(staging_root_path)"
+  else
+    local inferred_host="${host:-$(hostname -f 2>/dev/null || hostname || echo unknown)}"
+    staging_display="/var/lib/syncgitconfig/staging/${inferred_host:-unknown}"
+  fi
+  echo "Staging: $staging_display"
 
   if (( load_ok )); then
     echo "Apps:   ${#APP_NAMES[@]}"

--- a/opt/syncgitconfig/bin/syncgitconfig-watch
+++ b/opt/syncgitconfig/bin/syncgitconfig-watch
@@ -62,7 +62,8 @@ main() {
     err "repo_path no es un checkout Git válido: $repo_path"
   fi
 
-  local STAGING_ROOT="$CFG_staging_path/$CFG_host"
+  local STAGING_ROOT
+  STAGING_ROOT="$(staging_root_path)"
   local REPO_HOST_ROOT
   REPO_HOST_ROOT="$(repo_host_root_path)"
 

--- a/opt/syncgitconfig/config.example.yaml
+++ b/opt/syncgitconfig/config.example.yaml
@@ -11,7 +11,7 @@ repo_path: __REPO_PATH__        # Ruta local donde se clona el repo
 remote_url: __REMOTE_URL__      # URL remota del repo (HTTPS/SSH)
 env: __ENV__                    # Entorno (prod, pre, dev, test)
 host: __HOST__                  # Hostname (o "auto" para autodetectar)
-repo_layout: hierarchical       # hierarchical (por defecto) | flat (escribe en la raíz del repo)
+repo_layout: hierarchical       # hierarchical (env/apps, por defecto) | hierarchical_host (legado) | flat
 cooldown_seconds: __COOLDOWN__  # Intervalo en segundos entre syncs
 # staging_path: /var/lib/syncgitconfig/staging  # Opcional: staging personalizado
 

--- a/opt/syncgitconfig/lib/common.sh
+++ b/opt/syncgitconfig/lib/common.sh
@@ -74,11 +74,34 @@ ensure_app_entry() {
 }
 
 repo_host_root_path() {
-  if [[ "$CFG_repo_layout" == "flat" ]]; then
-    printf '%s\n' "$CFG_repo_path"
-  else
-    printf '%s\n' "$CFG_repo_path/envs/$CFG_env/hosts/$CFG_host"
-  fi
+  case "$CFG_repo_layout" in
+    flat)
+      printf '%s\n' "$CFG_repo_path"
+      ;;
+    hierarchical)
+      printf '%s\n' "$CFG_repo_path/envs/$CFG_env"
+      ;;
+    hierarchical_host)
+      printf '%s\n' "$CFG_repo_path/envs/$CFG_env/hosts/$CFG_host"
+      ;;
+    *)
+      printf '%s\n' "$CFG_repo_path/envs/$CFG_env"
+      ;;
+  esac
+}
+
+staging_root_path() {
+  case "$CFG_repo_layout" in
+    flat|hierarchical_host)
+      printf '%s\n' "$CFG_staging_path/$CFG_host"
+      ;;
+    hierarchical)
+      printf '%s\n' "$CFG_staging_path/$CFG_env"
+      ;;
+    *)
+      printf '%s\n' "$CFG_staging_path/$CFG_env"
+      ;;
+  esac
 }
 
 build_command_string() {
@@ -525,11 +548,14 @@ load_config_yaml() {
 
   local layout_lc="${CFG_repo_layout,,}"
   case "$layout_lc" in
-    ""|hierarchical|default|env_host|nested)
+    ""|hierarchical|env|environment|env_only)
       CFG_repo_layout="hierarchical"
       ;;
     flat|root)
       CFG_repo_layout="flat"
+      ;;
+    hierarchical_host|env_host|host|default|nested|legacy)
+      CFG_repo_layout="hierarchical_host"
       ;;
     *)
       warn "repo_layout desconocido '$CFG_repo_layout'; usando 'hierarchical'."

--- a/readme.md
+++ b/readme.md
@@ -54,8 +54,8 @@ Staging y commit:
 
 ```
 (origenes /etc/... )
-   → /var/lib/syncgitconfig/staging/<host>/apps/<app>/… 
-   → /opt/configs-host/envs/<env>/hosts/<host>/apps/<app>/…
+   → /var/lib/syncgitconfig/staging/<env>/apps/<app>/…
+   → /opt/configs-host/envs/<env>/apps/<app>/…
    → git add / commit / push (HTTPS o SSH según `auth.method`)
 ```
 
@@ -104,7 +104,7 @@ repo_path: /opt/configs-host
 remote_url: https://gitea.example.local/ORG/configs-host.git
 env: prod
 host: auto
-repo_layout: hierarchical     # o "flat" para escribir en la raíz del repo
+repo_layout: hierarchical     # hierarchical (env/apps, por defecto) | hierarchical_host (legado) | flat
 staging_path: /var/lib/syncgitconfig/staging
 cooldown_seconds: 60
 
@@ -159,7 +159,7 @@ exclude:
 #         strip_prefix: "/etc/systemd/system"
 ```
 
-* `repo_layout` define si el árbol se crea bajo `envs/<env>/hosts/<host>` (`hierarchical`, por defecto) o directamente en la raíz del repo (`flat`).
+* `repo_layout` define si el árbol se crea bajo `envs/<env>/…` (`hierarchical`, por defecto), conserva el nivel `hosts/<host>` (`hierarchical_host`) o escribe directamente en la raíz del repo (`flat`).
 * `environments.<env>.hosts.<host>.apps.<app>.paths` agrupa rutas bajo `apps/<app>` y acepta entradas simples o mapas `src`/`dest` para personalizar el destino relativo al repositorio.
 * `watch_paths` indica qué rutas vigilar; si no se define se derivan de `paths`/`apps`. Con `repo_layout: flat` y rutas declaradas en `apps` se ignora automáticamente.
 * `paths` crea snapshots planos bajo `paths/` (modo legacy sencillo) y admite directorios o archivos individuales.
@@ -215,15 +215,13 @@ Checkout local (ej.: `/opt/configs-host`):
 ├─ .git/
 └─ envs/
    └─ prod/
-      └─ hosts/
-         └─ <host-fqdn>/
-            └─ apps/
-               ├─ systemd/…      # desde /etc/systemd/system
-               ├─ ssh/…          # desde /etc/ssh o archivos sueltos
-               └─ monitoring/…   # desde /etc/nagios
+      └─ apps/
+         ├─ systemd/…      # desde /etc/systemd/system
+         ├─ ssh/…          # desde /etc/ssh o archivos sueltos
+         └─ monitoring/…   # desde /etc/nagios
 ```
 
-> Con `repo_layout: flat` los archivos se almacenan directamente bajo la raíz del repositorio (p. ej. `apps/…`, `paths/…`) sin los niveles `envs/<env>/hosts/<host>`.
+> Con `repo_layout: hierarchical_host` se conserva el nivel `hosts/<host>`. Con `repo_layout: flat` los archivos se almacenan directamente bajo la raíz del repositorio (p. ej. `apps/…`, `paths/…`).
 
 ---
 


### PR DESCRIPTION
## Summary
- add layout helpers so hierarchical repos now store snapshots under env/app paths and keep a legacy option for host-prefixed trees
- reuse the new helpers from the run, watch and status commands and accept --once as a no-op compatibility flag
- refresh documentation and configuration examples to describe the env-based layout and legacy host option

## Testing
- ./opt/syncgitconfig/bin/syncgitconfig-run --help
- ./opt/syncgitconfig/bin/syncgitconfig-status | head


------
https://chatgpt.com/codex/tasks/task_e_68d16781e8fc832d9869a3c84a64a6e4