### PR TITLE
Ensure HTTPS token credentials are provisioned

### DIFF
--- a/opt/syncgitconfig/bin/syncgitconfig-pull
+++ b/opt/syncgitconfig/bin/syncgitconfig-pull
@@ -12,6 +12,8 @@ main() {
     exit 1
   fi
 
+  ensure_https_token_credentials
+
   local repo="$CFG_repo_path"
   [[ -d "$repo/.git" ]] || { err "$repo no es un repo Git válido"; exit 1; }
 

--- a/opt/syncgitconfig/bin/syncgitconfig-reconfigure
+++ b/opt/syncgitconfig/bin/syncgitconfig-reconfigure
@@ -8,6 +8,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 main() {
   load_config_yaml "$CONF_PATH"
+  ensure_https_token_credentials
   ensure_git_repo_ready "$CFG_repo_path" "$CFG_remote_url" "$AUTH_token_file"
 
   # Si hay token_inline, migrarlo de nuevo (por si se actualiza)

--- a/opt/syncgitconfig/bin/syncgitconfig-run
+++ b/opt/syncgitconfig/bin/syncgitconfig-run
@@ -165,6 +165,8 @@ main() {
   acquire_lock_or_exit
   respect_cooldown_or_exit
 
+  ensure_https_token_credentials
+
   ensure_git_repo_ready "$CFG_repo_path" "$CFG_remote_url" "$AUTH_token_file"
 
   local STAGING_ROOT


### PR DESCRIPTION
## Summary
- add helpers to build the HTTPS credential store file from the configured token when required
- call the helper from the run, reconfigure and pull entrypoints so pushes and pulls keep working once new files are synced

## Testing
- bash -n opt/syncgitconfig/lib/common.sh
- bash -n opt/syncgitconfig/bin/syncgitconfig-run
- bash -n opt/syncgitconfig/bin/syncgitconfig-reconfigure
- bash -n opt/syncgitconfig/bin/syncgitconfig-pull

------
https://chatgpt.com/codex/tasks/task_e_68d16ebf2364832d9c512cb247aa021e