### PR TITLE
Ensure git commands reuse credential helper for https_token

### DIFF
--- a/opt/syncgitconfig/lib/common.sh
+++ b/opt/syncgitconfig/lib/common.sh
@@ -293,10 +293,16 @@ ensure_https_token_credentials() {
 }
 
 run_git() {
+  local -a git_cmd=(git)
+
+  if [[ "$AUTH_effective_method" == "https_token" && -n "${AUTH_token_file:-}" ]]; then
+    git_cmd+=(-c "credential.helper=store --file=$AUTH_token_file")
+  fi
+
   if (( ${#AUTH_GIT_ENVS[@]} )); then
-    env "${AUTH_GIT_ENVS[@]}" git "$@"
+    env "${AUTH_GIT_ENVS[@]}" "${git_cmd[@]}" "$@"
   else
-    git "$@"
+    "${git_cmd[@]}" "$@"
   fi
 }
 


### PR DESCRIPTION
## Summary
- ensure git operations executed through run_git always include the configured credential.helper when using https_token authentication

## Testing
- ./opt/syncgitconfig/bin/syncgitconfig-run --help

------
https://chatgpt.com/codex/tasks/task_e_68d174eb8748832dac3330ca21af66c1