### PR TITLE
Generar README por app y robustecer credenciales

### DIFF
--- a/opt/syncgitconfig/README.md
+++ b/opt/syncgitconfig/README.md
@@ -17,7 +17,10 @@ Backup granular de configuraciones por servidor, en Git (HTTPS/SSH), con staging
 4. Sembrar snapshot inicial (opcional): `/opt/syncgitconfig/bin/syncgitconfig-seed`.
 5. Verifica con `/opt/syncgitconfig/bin/syncgitconfig-status`.
 
+> Después de cualquier cambio en `syncgitconfig.yaml`, ejecuta `/opt/syncgitconfig/bin/syncgitconfig-reconfigure` para refrescar credenciales y reiniciar los servicios (`syncgitconfig.service` + watcher).
+
 ## Notas
 
 - Cada ejecución de `syncgitconfig-run` contrasta los destinos configurados y elimina del staging/repositorio las carpetas que ya no aparecen en el YAML (apps, paths o watch_paths). Tras quitar una app o ruta basta con lanzar un run para que desaparezca del repo.
+- Cada carpeta de app contiene un `README.md` autogenerado con el listado de orígenes sincronizados y la fecha de la última ejecución que produjo cambios.
 - Para desinstalar usa `sudo /opt/syncgitconfig/uninstall.sh --purge --purge-repo` si necesitas una limpieza total (estado, logs y repo local). El script acepta `--dry-run` para revisar qué se borrará y comprueba que `repo_path` pertenezca al host antes de eliminarlo.

--- a/opt/syncgitconfig/bin/syncgitconfig-reconfigure
+++ b/opt/syncgitconfig/bin/syncgitconfig-reconfigure
@@ -16,8 +16,9 @@ main() {
     "$SCRIPT_DIR/syncgitconfig-install"
   fi
 
+  systemctl restart syncgitconfig.service || true
   systemctl restart syncgitconfig-watch.service || true
-  ok "Reconfiguración aplicada."
+  ok "Reconfiguración aplicada y servicios reiniciados."
 }
 
 main "$@"

--- a/opt/syncgitconfig/bin/syncgitconfig-run
+++ b/opt/syncgitconfig/bin/syncgitconfig-run
@@ -11,6 +11,14 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 BYPASS_COOLDOWN=0
 SEED_MODE=0
 
+declare -a SRC_EFFECTIVE_TYPES=()
+declare -a SRC_EFFECTIVE_STRIPS=()
+declare -a SRC_EFFECTIVE_DEST_BASE=()
+declare -a SRC_EFFECTIVE_TARGET_RELS=()
+declare -a APP_CHANGED_FLAGS=()
+RUN_TIMESTAMP=""
+__README_UPDATED=0
+
 usage() {
   cat <<'USAGE'
 Uso: syncgitconfig-run [--no-cooldown] [--seed] [--once]
@@ -156,6 +164,94 @@ compute_file_target_rel() {
   normalize_rel_path "$result"
 }
 
+write_app_readme() {
+  local app_idx="$1" app_name="$2" dest="$3" staged_app_root="$4" app_changed="$5" timestamp="$6"
+
+  __README_UPDATED=0
+
+  if [[ -z "$dest" || "$dest" == "." ]]; then
+    return
+  fi
+
+  local readme_path="$staged_app_root/README.md"
+  local last_sync_existing=""
+  if [[ -f "$readme_path" ]]; then
+    last_sync_existing="$(grep -E '^Última sincronización:' "$readme_path" 2>/dev/null | head -n1 | cut -d':' -f2- | sed 's/^ *//')"
+  fi
+
+  local last_sync_value="$last_sync_existing"
+  if (( app_changed )); then
+    last_sync_value="$timestamp"
+  elif [[ -z "$last_sync_existing" ]]; then
+    last_sync_value="$timestamp"
+  fi
+
+  local tmp_file
+  tmp_file="$(mktemp "${TMPDIR:-/tmp}/syncgitconfig-app-readme.XXXXXX")"
+
+  {
+    printf '# %s\n\n' "$app_name"
+    printf '* Destino en el repositorio: `%s`\n' "$dest"
+    if [[ -n "$last_sync_value" ]]; then
+      printf '* Última sincronización: %s\n\n' "$last_sync_value"
+    else
+      printf '* Última sincronización: pendiente\n\n'
+    fi
+    printf '## Orígenes sincronizados\n\n'
+
+    local found_source=0
+    for ((idx=0; idx<${#SRC_APPIDX[@]}; idx++)); do
+      if (( SRC_APPIDX[idx] == app_idx )); then
+        found_source=1
+        local src="${SRC_PATHS[$idx]}"
+        local typ="${SRC_EFFECTIVE_TYPES[$idx]:-${SRC_TYPES[$idx]}}"
+        [[ -n "$typ" ]] || typ="auto"
+        local strip_value="${SRC_EFFECTIVE_STRIPS[$idx]:-${SRC_STRIPS[$idx]}}"
+        local strip_display="$strip_value"
+        if [[ -z "$strip_display" ]]; then
+          strip_display="(auto)"
+        else
+          strip_display="\`$strip_display\`"
+        fi
+        local dest_base="${SRC_EFFECTIVE_DEST_BASE[$idx]:-$dest}"
+        [[ -n "$dest_base" ]] || dest_base="$dest"
+        local target_display="${SRC_EFFECTIVE_TARGET_RELS[$idx]:-}"
+        if [[ -n "$target_display" ]]; then
+          target_display="\`$target_display\`"
+        else
+          if [[ -n "$dest_base" && "$dest_base" != "." ]]; then
+            target_display="\`$dest_base\`"
+          elif [[ "$dest_base" == "." ]]; then
+            target_display="\`.\` (raíz del repositorio)"
+          else
+            target_display="(carpeta del app)"
+          fi
+        fi
+        local declared_dest="${SRC_DESTS[$idx]}"
+        printf '- `%s`\n' "$src"
+        printf '  - Tipo efectivo: %s\n' "$typ"
+        printf '  - Strip aplicado: %s\n' "$strip_display"
+        printf '  - Destino relativo: %s\n' "$target_display"
+        if [[ -n "$declared_dest" && "$declared_dest" != "." ]]; then
+          printf '  - Destino personalizado declarado: `%s`\n' "$declared_dest"
+        fi
+        printf '\n'
+      fi
+    done
+
+    if (( ! found_source )); then
+      printf '_Sin rutas declaradas._\n'
+    fi
+  } >"$tmp_file"
+
+  if [[ ! -f "$readme_path" ]] || ! cmp -s "$tmp_file" "$readme_path"; then
+    install -D -m 0644 "$tmp_file" "$readme_path"
+    __README_UPDATED=1
+  fi
+
+  rm -f "$tmp_file"
+}
+
 main() {
   parse_args "$@"
 
@@ -174,6 +270,13 @@ main() {
   local REPO_HOST_ROOT
   REPO_HOST_ROOT="$(repo_host_root_path)"
   mkdir -p "$STAGING_ROOT" "$REPO_HOST_ROOT"
+
+  RUN_TIMESTAMP="$(date +'%Y-%m-%d %H:%M:%S %Z')"
+  SRC_EFFECTIVE_TYPES=()
+  SRC_EFFECTIVE_STRIPS=()
+  SRC_EFFECTIVE_DEST_BASE=()
+  SRC_EFFECTIVE_TARGET_RELS=()
+  APP_CHANGED_FLAGS=()
 
   local staging_changed=0
 
@@ -242,8 +345,10 @@ main() {
     [[ -z "$dest" ]] && dest="apps/$app"
     dest="${dest%/}"
     APP_DESTS[$i]="$dest"
+    APP_CHANGED_FLAGS[$i]=0
     if [[ -n "$dest" && "$dest" != "." ]]; then
       NEW_MANAGED_DIRS["$dest"]=1
+      NEW_MANAGED_FILES["$dest/README.md"]=1
     fi
   done
 
@@ -285,19 +390,23 @@ main() {
       fi
     fi
 
+    local target_rel=""
     if [[ "$effective_type" == "dir" ]]; then
-      local target_rel
       target_rel="$(compute_dir_target_rel "$src" "$effective_strip" "$dest_base")"
       if [[ -n "$target_rel" ]]; then
         NEW_MANAGED_DIRS["$target_rel"]=1
       fi
     elif [[ "$effective_type" == "file" ]]; then
-      local target_rel
       target_rel="$(compute_file_target_rel "$src" "$effective_strip" "$dest_base")"
       if [[ -n "$target_rel" ]]; then
         NEW_MANAGED_FILES["$target_rel"]=1
       fi
     fi
+
+    SRC_EFFECTIVE_TYPES[$s]="$effective_type"
+    SRC_EFFECTIVE_STRIPS[$s]="$effective_strip"
+    SRC_EFFECTIVE_DEST_BASE[$s]="$dest_base"
+    SRC_EFFECTIVE_TARGET_RELS[$s]="$target_rel"
   done
 
   PATH_DEST_RELS=()
@@ -414,6 +523,7 @@ main() {
             fi
             if [[ -n "$rsync_out" ]]; then
               staging_changed=1
+              APP_CHANGED_FLAGS[$i]=1
               log "DIR: $src -> $display (cambios)"
               while IFS= read -r line; do log "    $line"; done <<<"$rsync_out"
             else
@@ -433,6 +543,7 @@ main() {
             else
               install -D -m 0644 "$src" "$tgt"
               staging_changed=1
+              APP_CHANGED_FLAGS[$i]=1
               log "FILE: $src -> $display (actualizado)"
             fi
           else
@@ -443,6 +554,12 @@ main() {
         fi
       fi
     done
+
+    write_app_readme "$i" "$app" "$dest" "$staged_app_root" "${APP_CHANGED_FLAGS[$i]:-0}" "$RUN_TIMESTAMP"
+    if (( __README_UPDATED )); then
+      staging_changed=1
+      APP_CHANGED_FLAGS[$i]=1
+    fi
   done
 
   if (( ${#EFFECTIVE_PATHS[@]} )); then

--- a/opt/syncgitconfig/lib/common.sh
+++ b/opt/syncgitconfig/lib/common.sh
@@ -240,20 +240,23 @@ ensure_https_token_credentials() {
   chmod 700 "$cred_dir" 2>/dev/null || true
 
   local url="$CFG_remote_url"
-  local scheme rest
-  if [[ "$url" == https://* ]]; then
-    scheme="https"
-    rest="${url#https://}"
-  elif [[ "$url" == http://* ]]; then
-    scheme="http"
-    rest="${url#http://}"
-  else
-    warn "auth.method=https_token pero remote_url no es HTTP(S): $(redact_remote_url "$url")"
-    return
+  local scheme="" rest=""
+  if [[ "$url" == *://* ]]; then
+    local proto="${url%%://*}"
+    rest="${url#*://}"
+    local proto_lc="${proto,,}"
+    case "$proto_lc" in
+      https|http)
+        scheme="$proto_lc"
+        ;;
+      *)
+        scheme=""
+        ;;
+    esac
   fi
 
-  if [[ -z "$rest" ]]; then
-    warn "No se pudo derivar el host remoto desde remote_url: $(redact_remote_url "$url")"
+  if [[ -z "$scheme" || -z "$rest" ]]; then
+    warn "auth.method=https_token pero remote_url no es HTTP(S): $(redact_remote_url "$url")"
     return
   fi
 
@@ -347,16 +350,18 @@ apply_environment_apps() {
 
 determine_auth_effective_method() {
   local url="$CFG_remote_url"
-  local method="$AUTH_method"
+  local url_lc="${url,,}"
+  local method_raw="$AUTH_method"
+  local method="${method_raw,,}"
   local inline_credentials=0
-  if [[ "$url" =~ ^https?://[^/@]+@ ]] || [[ "$url" =~ ^https?://[^/]*:[^@]+@ ]]; then
+  if [[ "$url_lc" =~ ^https?://[^/@]+@ ]] || [[ "$url_lc" =~ ^https?://[^/]*:[^@]+@ ]]; then
     inline_credentials=1
   fi
 
   if [[ -z "$method" ]]; then
-    if [[ "$url" == git@* || "$url" == ssh://* ]]; then
+    if [[ "$url_lc" == git@* || "$url_lc" == ssh://* ]]; then
       method="ssh"
-    elif [[ "$url" =~ ^https?:// || "$url" =~ ^http:// ]]; then
+    elif [[ "$url_lc" =~ ^https?:// || "$url_lc" =~ ^http:// ]]; then
       if (( inline_credentials )); then
         method="https_inline"
       elif [[ -n "$AUTH_token_file" || -n "$AUTH_token_inline" ]]; then

--- a/readme.md
+++ b/readme.md
@@ -6,6 +6,7 @@ Backup **granular** de configuraciones por **servidor** usando **Git** (HTTPS co
 * **Modelo por app**: agrupas rutas como “apps” (systemd, ssh, monitoring, …) declaradas por entorno/host.
 * **Seguro**: excluyes secretos; token con permisos mínimos; sin `.git` en `/etc`.
 * **Automático**: watcher + cooldown (60 s) para evitar tormentas de commits.
+* **Documentado**: cada app genera un `README.md` con sus orígenes y la fecha de la última sincronización.
 
 ---
 
@@ -216,9 +217,15 @@ Checkout local (ej.: `/opt/configs-host`):
 └─ envs/
    └─ prod/
       └─ apps/
-         ├─ systemd/…      # desde /etc/systemd/system
-         ├─ ssh/…          # desde /etc/ssh o archivos sueltos
-         └─ monitoring/…   # desde /etc/nagios
+         ├─ systemd/
+         │  ├─ README.md   # resumen de orígenes + última sincronización
+         │  └─ *.service
+         ├─ ssh/
+         │  ├─ README.md
+         │  └─ sshd_config …
+         └─ monitoring/
+            ├─ README.md
+            └─ …
 ```
 
 > Con `repo_layout: hierarchical_host` se conserva el nivel `hosts/<host>`. Con `repo_layout: flat` los archivos se almacenan directamente bajo la raíz del repositorio (p. ej. `apps/…`, `paths/…`).
@@ -227,17 +234,29 @@ Checkout local (ej.: `/opt/configs-host`):
 
 ## Operativa habitual
 
+### Chuleta rápida
+
+| Acción | Comando | Detalle |
+| --- | --- | --- |
+| Revisar estado | `/opt/syncgitconfig/bin/syncgitconfig-status` | Muestra rutas vigiladas, remoto y último resultado del watcher. |
+| Ejecutar pasada inmediata | `systemctl start syncgitconfig.service` | Lanza `syncgitconfig-run` en modo *oneshot* con la configuración vigente. |
+| Reaplicar configuración tras editar el YAML | `/opt/syncgitconfig/bin/syncgitconfig-reconfigure` | Regenera credenciales si es necesario y reinicia `syncgitconfig.service` + `syncgitconfig-watch.service`. |
+| Sembrar snapshot inicial | `/opt/syncgitconfig/bin/syncgitconfig-seed` | Copia todas las rutas declaradas a *staging*/repo aunque estén vacíos. |
+| Revisar logs en vivo | `tail -f /var/log/syncgitconfig/syncgitconfig.log` | Útil para ver qué apps se sincronizan y cuándo. |
+
 **Estado rápido**
 
 ```bash
 /opt/syncgitconfig/bin/syncgitconfig-status
 ```
 
-**Reconfigurar remoto/token sin reinstalar**
+**Reaplicar configuración y reiniciar servicios**
 
 ```bash
 /opt/syncgitconfig/bin/syncgitconfig-reconfigure
 ```
+
+> Actualiza credenciales HTTPS/SSH, asegura el checkout local y reinicia el servicio `syncgitconfig.service` (one-shot) junto con el watcher para que la nueva configuración quede activa de inmediato.
 
 **Forzar una pasada manual**
 


### PR DESCRIPTION
## Resumen
- Normalicé la detección del método de autenticación HTTPS para soportar `remote_url` y `auth.method` con mayúsculas y asegurar que el helper de credenciales funcione siempre.
- Añadí la generación automática de `README.md` en cada app con el listado de orígenes sincronizados y la última fecha de sincronización, evitando commits innecesarios cuando no hay cambios.
- Actualicé `syncgitconfig-reconfigure` para reiniciar tanto el servicio one-shot como el watcher tras editar el YAML y documenté los nuevos flujos en los README principales.

## Pruebas
- `bash -n opt/syncgitconfig/bin/syncgitconfig-run`
- `bash -n opt/syncgitconfig/bin/syncgitconfig-reconfigure`
- `bash -n opt/syncgitconfig/lib/common.sh`


------
https://chatgpt.com/codex/tasks/task_e_68d182c53b9c832d9e479dca20357cc0