### PR TITLE
Refrescar credenciales antes de push y etiquetar apps cambiadas

### DIFF
--- a/opt/syncgitconfig/README.md
+++ b/opt/syncgitconfig/README.md
@@ -17,7 +17,10 @@ Backup granular de configuraciones por servidor, en Git (HTTPS/SSH), con staging
 4. Sembrar snapshot inicial (opcional): `/opt/syncgitconfig/bin/syncgitconfig-seed`.
 5. Verifica con `/opt/syncgitconfig/bin/syncgitconfig-status`.
 
+> Después de cualquier cambio en `syncgitconfig.yaml`, ejecuta `/opt/syncgitconfig/bin/syncgitconfig-reconfigure` para refrescar credenciales y reiniciar los servicios (`syncgitconfig.service` + watcher).
+
 ## Notas
 
 - Cada ejecución de `syncgitconfig-run` contrasta los destinos configurados y elimina del staging/repositorio las carpetas que ya no aparecen en el YAML (apps, paths o watch_paths). Tras quitar una app o ruta basta con lanzar un run para que desaparezca del repo.
+- Cada carpeta de app contiene un `README.md` autogenerado con el listado de orígenes sincronizados y la fecha de la última ejecución que produjo cambios.
 - Para desinstalar usa `sudo /opt/syncgitconfig/uninstall.sh --purge --purge-repo` si necesitas una limpieza total (estado, logs y repo local). El script acepta `--dry-run` para revisar qué se borrará y comprueba que `repo_path` pertenezca al host antes de eliminarlo.

--- a/opt/syncgitconfig/bin/syncgitconfig-reconfigure
+++ b/opt/syncgitconfig/bin/syncgitconfig-reconfigure
@@ -16,8 +16,9 @@ main() {
     "$SCRIPT_DIR/syncgitconfig-install"
   fi
 
+  systemctl restart syncgitconfig.service || true
   systemctl restart syncgitconfig-watch.service || true
-  ok "Reconfiguración aplicada."
+  ok "Reconfiguración aplicada y servicios reiniciados."
 }
 
 main "$@"

--- a/opt/syncgitconfig/bin/syncgitconfig-run
+++ b/opt/syncgitconfig/bin/syncgitconfig-run
@@ -11,6 +11,14 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 BYPASS_COOLDOWN=0
 SEED_MODE=0
 
+declare -a SRC_EFFECTIVE_TYPES=()
+declare -a SRC_EFFECTIVE_STRIPS=()
+declare -a SRC_EFFECTIVE_DEST_BASE=()
+declare -a SRC_EFFECTIVE_TARGET_RELS=()
+declare -a APP_CHANGED_FLAGS=()
+RUN_TIMESTAMP=""
+__README_UPDATED=0
+
 usage() {
   cat <<'USAGE'
 Uso: syncgitconfig-run [--no-cooldown] [--seed] [--once]
@@ -156,6 +164,100 @@ compute_file_target_rel() {
   normalize_rel_path "$result"
 }
 
+slugify_app_tag() {
+  local value="$1"
+  value="${value//[^A-Za-z0-9._-]/_}"
+  echo "$value"
+}
+
+write_app_readme() {
+  local app_idx="$1" app_name="$2" dest="$3" staged_app_root="$4" app_changed="$5" timestamp="$6"
+
+  __README_UPDATED=0
+
+  if [[ -z "$dest" || "$dest" == "." ]]; then
+    return
+  fi
+
+  local readme_path="$staged_app_root/README.md"
+  local last_sync_existing=""
+  if [[ -f "$readme_path" ]]; then
+    last_sync_existing="$(grep -E '^Última sincronización:' "$readme_path" 2>/dev/null | head -n1 | cut -d':' -f2- | sed 's/^ *//')"
+  fi
+
+  local last_sync_value="$last_sync_existing"
+  if (( app_changed )); then
+    last_sync_value="$timestamp"
+  elif [[ -z "$last_sync_existing" ]]; then
+    last_sync_value="$timestamp"
+  fi
+
+  local tmp_file
+  tmp_file="$(mktemp "${TMPDIR:-/tmp}/syncgitconfig-app-readme.XXXXXX")"
+
+  {
+    printf '# %s\n\n' "$app_name"
+    printf '* Destino en el repositorio: `%s`\n' "$dest"
+    if [[ -n "$last_sync_value" ]]; then
+      printf '* Última sincronización: %s\n\n' "$last_sync_value"
+    else
+      printf '* Última sincronización: pendiente\n\n'
+    fi
+    printf '## Orígenes sincronizados\n\n'
+
+    local found_source=0
+    for ((idx=0; idx<${#SRC_APPIDX[@]}; idx++)); do
+      if (( SRC_APPIDX[idx] == app_idx )); then
+        found_source=1
+        local src="${SRC_PATHS[$idx]}"
+        local typ="${SRC_EFFECTIVE_TYPES[$idx]:-${SRC_TYPES[$idx]}}"
+        [[ -n "$typ" ]] || typ="auto"
+        local strip_value="${SRC_EFFECTIVE_STRIPS[$idx]:-${SRC_STRIPS[$idx]}}"
+        local strip_display="$strip_value"
+        if [[ -z "$strip_display" ]]; then
+          strip_display="(auto)"
+        else
+          strip_display="\`$strip_display\`"
+        fi
+        local dest_base="${SRC_EFFECTIVE_DEST_BASE[$idx]:-$dest}"
+        [[ -n "$dest_base" ]] || dest_base="$dest"
+        local target_display="${SRC_EFFECTIVE_TARGET_RELS[$idx]:-}"
+        if [[ -n "$target_display" ]]; then
+          target_display="\`$target_display\`"
+        else
+          if [[ -n "$dest_base" && "$dest_base" != "." ]]; then
+            target_display="\`$dest_base\`"
+          elif [[ "$dest_base" == "." ]]; then
+            target_display="\`.\` (raíz del repositorio)"
+          else
+            target_display="(carpeta del app)"
+          fi
+        fi
+        local declared_dest="${SRC_DESTS[$idx]}"
+        printf '- `%s`\n' "$src"
+        printf '  - Tipo efectivo: %s\n' "$typ"
+        printf '  - Strip aplicado: %s\n' "$strip_display"
+        printf '  - Destino relativo: %s\n' "$target_display"
+        if [[ -n "$declared_dest" && "$declared_dest" != "." ]]; then
+          printf '  - Destino personalizado declarado: `%s`\n' "$declared_dest"
+        fi
+        printf '\n'
+      fi
+    done
+
+    if (( ! found_source )); then
+      printf '_Sin rutas declaradas._\n'
+    fi
+  } >"$tmp_file"
+
+  if [[ ! -f "$readme_path" ]] || ! cmp -s "$tmp_file" "$readme_path"; then
+    install -D -m 0644 "$tmp_file" "$readme_path"
+    __README_UPDATED=1
+  fi
+
+  rm -f "$tmp_file"
+}
+
 main() {
   parse_args "$@"
 
@@ -174,6 +276,13 @@ main() {
   local REPO_HOST_ROOT
   REPO_HOST_ROOT="$(repo_host_root_path)"
   mkdir -p "$STAGING_ROOT" "$REPO_HOST_ROOT"
+
+  RUN_TIMESTAMP="$(date +'%Y-%m-%d %H:%M:%S %Z')"
+  SRC_EFFECTIVE_TYPES=()
+  SRC_EFFECTIVE_STRIPS=()
+  SRC_EFFECTIVE_DEST_BASE=()
+  SRC_EFFECTIVE_TARGET_RELS=()
+  APP_CHANGED_FLAGS=()
 
   local staging_changed=0
 
@@ -242,8 +351,10 @@ main() {
     [[ -z "$dest" ]] && dest="apps/$app"
     dest="${dest%/}"
     APP_DESTS[$i]="$dest"
+    APP_CHANGED_FLAGS[$i]=0
     if [[ -n "$dest" && "$dest" != "." ]]; then
       NEW_MANAGED_DIRS["$dest"]=1
+      NEW_MANAGED_FILES["$dest/README.md"]=1
     fi
   done
 
@@ -285,19 +396,23 @@ main() {
       fi
     fi
 
+    local target_rel=""
     if [[ "$effective_type" == "dir" ]]; then
-      local target_rel
       target_rel="$(compute_dir_target_rel "$src" "$effective_strip" "$dest_base")"
       if [[ -n "$target_rel" ]]; then
         NEW_MANAGED_DIRS["$target_rel"]=1
       fi
     elif [[ "$effective_type" == "file" ]]; then
-      local target_rel
       target_rel="$(compute_file_target_rel "$src" "$effective_strip" "$dest_base")"
       if [[ -n "$target_rel" ]]; then
         NEW_MANAGED_FILES["$target_rel"]=1
       fi
     fi
+
+    SRC_EFFECTIVE_TYPES[$s]="$effective_type"
+    SRC_EFFECTIVE_STRIPS[$s]="$effective_strip"
+    SRC_EFFECTIVE_DEST_BASE[$s]="$dest_base"
+    SRC_EFFECTIVE_TARGET_RELS[$s]="$target_rel"
   done
 
   PATH_DEST_RELS=()
@@ -414,6 +529,7 @@ main() {
             fi
             if [[ -n "$rsync_out" ]]; then
               staging_changed=1
+              APP_CHANGED_FLAGS[$i]=1
               log "DIR: $src -> $display (cambios)"
               while IFS= read -r line; do log "    $line"; done <<<"$rsync_out"
             else
@@ -433,6 +549,7 @@ main() {
             else
               install -D -m 0644 "$src" "$tgt"
               staging_changed=1
+              APP_CHANGED_FLAGS[$i]=1
               log "FILE: $src -> $display (actualizado)"
             fi
           else
@@ -443,6 +560,12 @@ main() {
         fi
       fi
     done
+
+    write_app_readme "$i" "$app" "$dest" "$staged_app_root" "${APP_CHANGED_FLAGS[$i]:-0}" "$RUN_TIMESTAMP"
+    if (( __README_UPDATED )); then
+      staging_changed=1
+      APP_CHANGED_FLAGS[$i]=1
+    fi
   done
 
   if (( ${#EFFECTIVE_PATHS[@]} )); then
@@ -522,7 +645,39 @@ main() {
     staging_has_content=0
   fi
 
-  git_commit_and_push "$CFG_repo_path" "$REPO_HOST_ROOT" "$CFG_env" "$CFG_host" "$STAGING_ROOT" "$staging_changed" "$staging_has_content"
+  local -a changed_apps=()
+  for ((idx=0; idx<${#APP_NAMES[@]}; idx++)); do
+    if (( APP_CHANGED_FLAGS[idx] )); then
+      changed_apps+=("${APP_NAMES[$idx]}")
+    fi
+  done
+
+  local app_tag=""
+  if (( ${#changed_apps[@]} == 1 )); then
+    app_tag="$(slugify_app_tag "${changed_apps[0]}")"
+  elif (( ${#changed_apps[@]} > 1 )); then
+    local joined=""
+    local limit="${#changed_apps[@]}"
+    (( limit > 3 )) && limit=3
+    local j
+    for ((j=0; j<limit; j++)); do
+      local slug
+      slug="$(slugify_app_tag "${changed_apps[$j]}")"
+      if [[ -z "$slug" ]]; then
+        continue
+      fi
+      if [[ -n "$joined" ]]; then
+        joined+="," 
+      fi
+      joined+="$slug"
+    done
+    app_tag="multi:${#changed_apps[@]}"
+    if [[ -n "$joined" ]]; then
+      app_tag+=":$joined"
+    fi
+  fi
+
+  git_commit_and_push "$CFG_repo_path" "$REPO_HOST_ROOT" "$CFG_env" "$CFG_host" "$STAGING_ROOT" "$staging_changed" "$staging_has_content" "$app_tag"
 
   ok "RUN completado."
   log "=== END $CFG_host ==="


### PR DESCRIPTION
## Resumen
- Refrescar el fichero de credenciales HTTPS justo antes de cada push cuando se usa `auth.method: https_token`.
- Etiquetar los commits automáticos con las apps modificadas y generar etiquetas seguras a partir de los nombres declarados.
- Documentar en el README principal un ejemplo del README autogenerado por app para clarificar el contenido esperado.

## Pruebas
- `bash -n opt/syncgitconfig/bin/syncgitconfig-run`
- `bash -n opt/syncgitconfig/lib/common.sh`


------
https://chatgpt.com/codex/tasks/task_e_68d182c53b9c832d9e479dca20357cc0