### PR TITLE
Refuerza credenciales HTTPS y etiquetas automáticas de apps

### DIFF
--- a/opt/syncgitconfig/bin/syncgitconfig-run
+++ b/opt/syncgitconfig/bin/syncgitconfig-run
@@ -639,7 +639,33 @@ main() {
     staging_has_content=0
   fi
 
-  git_commit_and_push "$CFG_repo_path" "$REPO_HOST_ROOT" "$CFG_env" "$CFG_host" "$STAGING_ROOT" "$staging_changed" "$staging_has_content"
+  local app_tag=""
+  if (( ${#APP_NAMES[@]} )); then
+    local changed_total=0
+    local -a changed_preview=()
+    for ((i=0; i<${#APP_NAMES[@]}; i++)); do
+      if (( ${APP_CHANGED_FLAGS[$i]:-0} )); then
+        ((changed_total++))
+        if (( ${#changed_preview[@]} < 3 )); then
+          local slug
+          slug="$(slugify_app_tag "${APP_NAMES[$i]}")"
+          if [[ -z "$slug" ]]; then
+            slug="app$changed_total"
+          fi
+          changed_preview+=("$slug")
+        fi
+      fi
+    done
+    if (( changed_total )); then
+      if (( changed_total > 3 )); then
+        changed_preview+=("mas$((changed_total - 3))")
+      fi
+      local IFS='+'
+      app_tag="${changed_preview[*]}"
+    fi
+  fi
+
+  git_commit_and_push "$CFG_repo_path" "$REPO_HOST_ROOT" "$CFG_env" "$CFG_host" "$STAGING_ROOT" "$staging_changed" "$staging_has_content" "$app_tag"
 
   ok "RUN completado."
   log "=== END $CFG_host ==="

--- a/readme.md
+++ b/readme.md
@@ -228,6 +228,24 @@ Checkout local (ej.: `/opt/configs-host`):
             └─ …
 ```
 
+Ejemplo de `README.md` autogenerado dentro de `apps/systemd/`:
+
+```markdown
+# systemd
+
+* Destino en el repositorio: `apps/systemd`
+* Última sincronización: 2024-02-29 12:34:56 UTC
+
+## Orígenes sincronizados
+
+- `/etc/systemd/system`
+  - Tipo efectivo: dir
+  - Strip aplicado: `(auto)`
+  - Destino relativo: `apps/systemd`
+```
+
+> La fecha mostrada se actualiza en cada pasada que detecta cambios en la aplicación.
+
 > Con `repo_layout: hierarchical_host` se conserva el nivel `hosts/<host>`. Con `repo_layout: flat` los archivos se almacenan directamente bajo la raíz del repositorio (p. ej. `apps/…`, `paths/…`).
 
 ---


### PR DESCRIPTION
## Summary
- Regenera el fichero de credenciales HTTPS justo antes de cada commit/push automático para evitar peticiones interactivas.
- Añade `slugify_app_tag` y etiqueta los commits con una vista previa saneada (hasta tres elementos) de las apps modificadas.
- Documenta en el README principal un ejemplo del `README.md` generado por aplicación con su ruta y fecha esperada.

## Testing
- shellcheck (no disponible en la imagen base)


------
https://chatgpt.com/codex/tasks/task_e_68d191d84d60832db1792cf3fc1f4929