### PR TITLE
Fix printf option parsing for README source entries

### DIFF
--- a/opt/syncgitconfig/bin/syncgitconfig-run
+++ b/opt/syncgitconfig/bin/syncgitconfig-run
@@ -228,7 +228,7 @@ write_app_readme() {
           fi
         fi
         local declared_dest="${SRC_DESTS[$idx]}"
-        printf '- `%s`\n' "$src"
+        printf -- '- `%s`\n' "$src"
         printf '  - Tipo efectivo: %s\n' "$typ"
         printf '  - Strip aplicado: %s\n' "$strip_display"
         printf '  - Destino relativo: %s\n' "$target_display"


### PR DESCRIPTION
## Summary
- prevent the README source list bullet printf call from being parsed as an option by passing `--` before the format string

## Testing
- ./opt/syncgitconfig/bin/syncgitconfig-run --help

------
https://chatgpt.com/codex/tasks/task_e_68d2dae41e0c832d92d12af157b9bad6