### PR TITLE
Fix post-increment exits under set -e

### DIFF
--- a/opt/syncgitconfig/bin/syncgitconfig-run
+++ b/opt/syncgitconfig/bin/syncgitconfig-run
@@ -645,7 +645,7 @@ main() {
     local -a changed_preview=()
     for ((i=0; i<${#APP_NAMES[@]}; i++)); do
       if (( ${APP_CHANGED_FLAGS[$i]:-0} )); then
-        ((changed_total++))
+        ((++changed_total))
         if (( ${#changed_preview[@]} < 3 )); then
           local slug
           slug="$(slugify_app_tag "${APP_NAMES[$i]}")"

--- a/opt/syncgitconfig/lib/common.sh
+++ b/opt/syncgitconfig/lib/common.sh
@@ -845,13 +845,13 @@ git_commit_and_push() {
     path="${status_line:3}"
     case "$code" in
       '!!')
-        ((ignored_count++))
+        ((++ignored_count))
         if (( ${#ignored_preview[@]} < 10 )); then
           ignored_preview+=("$path")
         fi
         ;;
       '??')
-        ((untracked_count++))
+        ((++untracked_count))
         if (( ${#untracked_preview[@]} < 10 )); then
           untracked_preview+=("$path")
         fi


### PR DESCRIPTION
## Summary
- update the sync run loop to pre-increment the changed counter so the oneshot service no longer aborts under `set -e`
- do the same for the ignored/untracked counters in `git_commit_and_push` to keep push reporting functional when Git lists items

## Testing
- CONF_PATH=/tmp/test.yaml LOG_DIR=/tmp/logs STATE_DIR=/tmp/state opt/syncgitconfig/bin/syncgitconfig-run
- bash -n opt/syncgitconfig/bin/syncgitconfig-run
- bash -n opt/syncgitconfig/lib/common.sh

------
https://chatgpt.com/codex/tasks/task_e_68d2dbd1ad4c832d974bb150680200c6